### PR TITLE
Enable Github Actions CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,24 @@
+name: PlatformIO CI
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.platformio/.cache
+          key: ${{ runner.os }}-pio
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.9'
+      - name: Install PlatformIO Core
+        run: pip install --upgrade platformio
+
+      - name: Build PlatformIO Project
+        run: pio run

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,16 @@ jobs:
           python-version: '3.9'
       - name: Install PlatformIO Core
         run: pip install --upgrade platformio
-
+      # needed for [env:linux] build
+      - name: Install Dependencies (libserialport)
+        run: |
+            git clone git://sigrok.org/libserialport
+            cd libserialport/
+            ./autogen.sh
+            ./configure
+            make -j4
+            sudo make install
+            cd ..
       - name: Build PlatformIO Project
         run: |
           # uncomment the #define BLYNK_TEMPLATE etc. to not get compile errors

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,4 +21,7 @@ jobs:
         run: pip install --upgrade platformio
 
       - name: Build PlatformIO Project
-        run: pio run
+        run: |
+          # uncomment the #define BLYNK_TEMPLATE etc. to not get compile errors
+          sed -i 's\//#define BLYNK_\#define BLYNK_\g' src/main.cpp
+          pio run


### PR DESCRIPTION
Adds free Github CI per [documentation](https://docs.platformio.org/en/latest/integration/ci/github-actions.html) and adds build and prepare steps specific for the Blynk example, i.e., installing libserialport (for `[env:linux]` build) and uncommenting the `#define BLYNK_...` dummy values so that the compile goes through.

Additionally, a status badge could be added to the README.md as
```
[![PlatformIO CI](https://github.com/blynkkk/BlynkNcpExample/actions/workflows/build.yml/badge.svg)](https://github.com/blynkkk/BlynkNcpExample/actions/workflows/build.yml)
```
e.g. for my fork

[![PlatformIO CI](https://github.com/maxgerhardt/BlynkNcpExample/actions/workflows/build.yml/badge.svg)](https://github.com/maxgerhardt/BlynkNcpExample/actions/workflows/build.yml)